### PR TITLE
bind prepends arguments instead of replacing them

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -41,8 +41,10 @@ if (typeof Object.create != 'function'){
     v: '1.2.2dev',
 
     bind: function (fn, context, args) {
+      args = args || [];
       return function (){
-        return fn.apply(context, args || arguments)
+        args.push.apply(args, arguments);
+        return fn.apply(context, args)
       }
     },
 


### PR DESCRIPTION
Instead of `snack.bind` using the optional args array to replace arguments, it prepends them to the actual arguments.

```
function toBind() { return 'args: ' + [].slice.call(arguments) }
var bound = snack.bind(toBind, window, ['a', 'b', 'c']);
bound(); // "args: a,b,c" - same in both versions
bound('d'); // "args: a,b,c,d" - would previously return "args: a,b,c"
```
