### PR TITLE
Unexpected result when query selector returns an empty array

### DIFF
--- a/src/wrap.js
+++ b/src/wrap.js
@@ -8,7 +8,7 @@
       nodes = query(nodes, context)
 
     // passed in single node
-    if (!nodes.length)
+    if (!snack.isArray(nodes))
       nodes = [nodes]
 
     var wrapper = Object.create(proto)


### PR DESCRIPTION
Try:

```
snack.wrap('.aNonDefinedClass').each(function (e) { console.log(e); }); 
```

For now, it logs an empty array. It should not log anything at all.
