### PR TITLE
Changed `open.async` to `options.async`.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -204,7 +204,7 @@
 
       var xhr = self.xhr
 
-      xhr.open(method.toUpperCase(), url, open.async, options.user, options.password)
+      xhr.open(method.toUpperCase(), url, options.async, options.user, options.password)
       if (options.user && 'withCredentials' in xhr) xhr.withCredentials = true
     
       xhr.onreadystatechange = snack.bind(self.onStateChange, self)


### PR DESCRIPTION
As written previously it was referencing the `window.open` function.
