### PR TITLE
Fix documentation for snack.request

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1450,7 +1450,7 @@ $('input').attach('keyup', function (){
 <h3>Arguments</h3>
 <ol>
   <li>
-    <code>params</code> (<b>object</b>)
+    <code>options</code> (<b>object</b>)
     <ul>
       <li><code>url</code> (<b>string</b>) - The url to request</li>
       <li><code>data</code> (<b>mixed</b>: optional) - A URI query string or object of key value pairs.</li>


### PR DESCRIPTION
Function signature uses the name "options" but then uses the name "params" in the arguments section.
